### PR TITLE
change from integers to bitsets

### DIFF
--- a/encode.cpp
+++ b/encode.cpp
@@ -2,7 +2,9 @@
 
 void prepend_identity(matrix& rows, const size_t n_bits)
 {
-    code_word prefix = (1 << (rows.size() + n_bits - 1));
+    // have to do this in two steps since literal 1 is 32-bit
+    code_word prefix = 1;
+    prefix <<= (rows.size() + n_bits - 1);
     for (size_t i = 0;  i < rows.size(); ++i, prefix >>= 1)
         rows[i] |= prefix;
 
@@ -62,9 +64,8 @@ std::vector<code_word> check_message(const std::vector<code_word>& message,
     return checktext;
 }
 
-// this is horribly inefficient - can redo in a clever way
-std::vector<code_word> words_with_at_most_n_bits(const uint64_t n,
-                                                 const uint64_t max_bits)
+std::vector<code_word> words_with_at_most_n_bits(const size_t n,
+                                                 const size_t max_bits)
 {
     std::vector<code_word> words;
     std::vector<size_t> ns; // ns = [0,1,2,..,max_bits - 1]
@@ -101,14 +102,14 @@ void combs(std::vector<std::vector<size_t>>& cs, const std::vector<size_t>& ss,
 }
 
 syndrome_table build_syn_table(const matrix& check_matrix,
-                               const uint64_t width,
-                               const uint64_t max_errors)
+                               const size_t width,
+                               const size_t max_errors)
 {
-    uint64_t n = width;
+    size_t n = width;
 
     syndrome_table s_table;
     std::vector<code_word> errors = words_with_at_most_n_bits(max_errors, n);
-    for (uint64_t i = 0; i < errors.size(); ++i)
+    for (size_t i = 0; i < errors.size(); ++i)
     {
         const code_word err = errors[i];
         const code_word check = check_symbol(err, check_matrix);

--- a/encode.cpp
+++ b/encode.cpp
@@ -1,27 +1,27 @@
 #include "encode.h"
 
-void prepend_identity(matrix& rows, const uint64_t n_bits)
+void prepend_identity(matrix& rows, const size_t n_bits)
 {
     code_word prefix = (1 << (rows.size() + n_bits - 1));
-    for (uint64_t i = 0;  i < rows.size(); ++i, prefix >>= 1)
-        rows[i] += prefix;
+    for (size_t i = 0;  i < rows.size(); ++i, prefix >>= 1)
+        rows[i] |= prefix;
 
     return;
 }
 
-void append_identity(matrix& rows, const uint64_t n_bits)
+void append_identity(matrix& rows, const size_t n_bits)
 {
-    uint64_t shift = n_bits - 1;
+    size_t shift = n_bits - 1;
     code_word prefix = (1 << shift);
-    for (uint64_t i = 0;  i < rows.size(); ++i, prefix >>= 1)
+    for (size_t i = 0;  i < rows.size(); ++i, prefix >>= 1)
     {
         rows[i] <<= (shift + 1);
-        rows[i] += prefix;
+        rows[i] |= prefix;
     }
     return;
 }
 
-matrix transpose(const matrix& m, const uint64_t n_bits)
+matrix transpose(const matrix& m, const size_t n_bits)
 {
     matrix tp;
     for (size_t i = 0; i < n_bits; ++i)
@@ -30,7 +30,7 @@ matrix transpose(const matrix& m, const uint64_t n_bits)
         for (size_t j = 0; j < m.size(); ++j)
         {
             wd <<= 1;
-            wd += ((m[j] >> i) & 1);
+            wd |= ((m[j] >> i) & BS1);
         }
         tp.push_back(wd);
     }
@@ -43,11 +43,11 @@ code_word check_symbol(const code_word r, const matrix& check_code)
 {
     code_word cipher = r;
     code_word check = 0;
-    for (code_word i = 0; i < check_code.size(); ++i)
+    for (size_t i = 0; i < check_code.size(); ++i)
     {
         check <<= 1;
         code_word dot = row_dot(cipher, check_code[i]);
-        check += dot;
+        check |= dot;
     }
     return check;
 }
@@ -106,7 +106,7 @@ syndrome_table build_syn_table(const matrix& check_matrix,
 {
     uint64_t n = width;
 
-    std::map<code_word, code_word> s_table;
+    syndrome_table s_table;
     std::vector<code_word> errors = words_with_at_most_n_bits(max_errors, n);
     for (uint64_t i = 0; i < errors.size(); ++i)
     {

--- a/encode.cpp
+++ b/encode.cpp
@@ -14,7 +14,8 @@ void prepend_identity(matrix& rows, const size_t n_bits)
 void append_identity(matrix& rows, const size_t n_bits)
 {
     size_t shift = n_bits - 1;
-    code_word prefix = (1 << shift);
+    code_word prefix = 1;
+    prefix <<= shift;
     for (size_t i = 0;  i < rows.size(); ++i, prefix >>= 1)
     {
         rows[i] <<= (shift + 1);

--- a/encode.h
+++ b/encode.h
@@ -11,13 +11,13 @@ std::vector<code_word> check_message(const std::vector<code_word>& message,
                                      const matrix& check_code);
 
 syndrome_table build_syn_table(const matrix& l_code,
-															 const uint64_t width,
-                               const uint64_t max_errors);
+															 const size_t width,
+                               const size_t max_errors);
 void print_syn_table(const syndrome_table& st, const size_t n_bits,
                      const size_t n_words);
 
-std::vector<code_word> words_with_at_most_n_bits(const uint64_t n,
-																								 const uint64_t max_bits);
+std::vector<code_word> words_with_at_most_n_bits(const size_t n,
+																								 const size_t max_bits);
 void combs(std::vector<std::vector<size_t>>& cs, const std::vector<size_t>& ss,
            std::vector<size_t>& combination,
            const size_t offset, const size_t k);

--- a/encode.h
+++ b/encode.h
@@ -2,11 +2,9 @@
 
 #include "matrix.h"
 
-typedef std::map<code_word, code_word> syndrome_table;
-
-void prepend_identity(matrix& rows, const uint64_t n_bits);
-void append_identity(matrix& rows, const uint64_t n_bits);
-matrix transpose(const matrix& m, const uint64_t n_bits);
+void prepend_identity(matrix& rows, const size_t n_bits);
+void append_identity(matrix& rows, const size_t n_bits);
+matrix transpose(const matrix& m, const size_t n_bits);
 
 code_word check_symbol(const code_word r, const matrix& check_code);
 std::vector<code_word> check_message(const std::vector<code_word>& message,

--- a/linearcode.cpp
+++ b/linearcode.cpp
@@ -60,8 +60,7 @@ code_word LinearCode::decode_symbol(const code_word r) const
     const code_word check = check_symbol(r, mv_check);
     if (BS0 == check)
         return (r >> mn_code_width);
-print_codeword(r, mn_code_width + code_word_size());
-print_codeword(check, mn_code_width);
+std::cout << check << std::endl;
     const code_word syndrome = mm_syndromes.at(check);
     code_word temp = row_add(r, syndrome);
 

--- a/linearcode.cpp
+++ b/linearcode.cpp
@@ -40,7 +40,7 @@ code_word LinearCode::encode_symbol(const code_word r) const
     code_word plain = reverse(r, code_word_size());
     code_word cipher = 0;
     for (size_t i = 0; i < code_word_size(); ++i, plain >>= 1)
-        if (1 == (plain & 1))
+        if (BS1 == (plain & BS1))
             cipher = row_add(cipher, mv_generator[i]);
 
     return cipher;
@@ -58,7 +58,7 @@ std::vector<code_word> LinearCode::encode_message(const std::vector<code_word>& 
 code_word LinearCode::decode_symbol(const code_word r) const
 {
     const code_word check = check_symbol(r, mv_check);
-    if (0 == check)
+    if (BS0 == check)
         return (r >> mn_code_width);
 print_codeword(r, mn_code_width + code_word_size());
 print_codeword(check, mn_code_width);
@@ -85,11 +85,12 @@ std::vector<code_word> LinearCode::decode_message(const std::vector<code_word>& 
 
 size_t LinearCode::calc_minimum_weight() const
 {
-    code_word max_word = 1;
+    unsigned long long max_word = 1;
     max_word <<= code_word_size();
     size_t min_wt = 1000;
-    for (code_word wd = 1; wd < max_word; ++wd)
+    for (unsigned long long wi = 1; wi < max_word; ++wi)
     {
+        const code_word wd = wi;
         const code_word test = encode_symbol(wd);
         const size_t test_wt = row_weight(test);
 
@@ -124,9 +125,10 @@ void LinearCode::print() const
 matrix LinearCode::get_extra_bits() const
 {
     matrix x_bits;
-    code_word mask = 1 << mn_code_width;
+    unsigned long long mask = (1 << mn_code_width) - 1;
+    code_word cw_mask = mask;
     for (size_t i = 0; i < mv_generator.size(); ++i)
-        x_bits.push_back(mv_generator[i] % mask);
+        x_bits.push_back(mv_generator[i] & cw_mask);
     
     return x_bits;
 }

--- a/linearcode.cpp
+++ b/linearcode.cpp
@@ -60,7 +60,7 @@ code_word LinearCode::decode_symbol(const code_word r) const
     const code_word check = check_symbol(r, mv_check);
     if (BS0 == check)
         return (r >> mn_code_width);
-std::cout << check << std::endl;
+
     const code_word syndrome = mm_syndromes.at(check);
     code_word temp = row_add(r, syndrome);
 
@@ -124,7 +124,10 @@ void LinearCode::print() const
 matrix LinearCode::get_extra_bits() const
 {
     matrix x_bits;
-    unsigned long long mask = (1 << mn_code_width) - 1;
+    unsigned long long mask = 1;
+    mask <<= mn_code_width;
+    mask -= 1;
+
     code_word cw_mask = mask;
     for (size_t i = 0; i < mv_generator.size(); ++i)
         x_bits.push_back(mv_generator[i] & cw_mask);

--- a/main.cpp
+++ b/main.cpp
@@ -118,6 +118,9 @@ int main (int argc, char **argv)
 
         SaveKeys(priv, pub, ".");
 
+        LinearCode   G =  std::get<1>(priv);
+        G.print();
+
         return 0;     
     }
 

--- a/main.cpp
+++ b/main.cpp
@@ -96,8 +96,9 @@ int main (int argc, char **argv)
 
         std::vector<matrix> mats = all(n_bits, false);
 
-        sort( mats.begin(), mats.end() );
-        mats.erase( unique( mats.begin(), mats.end() ), mats.end() );
+        // we will need to define a < operator for this to work
+        // sort( mats.begin(), mats.end() );
+        // mats.erase( unique( mats.begin(), mats.end() ), mats.end() );
         std::cout << "Found " << mats.size() << " " << n_bits << "-by-" << n_bits
                   << " orthognal matrices over F2" << std::endl;
 
@@ -134,12 +135,12 @@ int main (int argc, char **argv)
     if (RunMode::decode_message == mode)
     {
         McEliesePrivate covert = ReadPrivateKey(key_file);
-        std::vector<code_word> message = ReadCSV(message_file);
+        std::vector<code_word> message = ReadCSV(message_file, true);
 
         std::vector<code_word> plaintext = McE_decypt_message(covert, message);
 
         for (size_t i = 0; i < plaintext.size(); ++i)
-            std::cout << plaintext[i] << (i + 1 == plaintext.size() ? "\n" : ",");
+            std::cout << plaintext[i].to_ullong() << (i + 1 == plaintext.size() ? "\n" : ",");
     }
 
     return 0;

--- a/matrix.cpp
+++ b/matrix.cpp
@@ -12,7 +12,7 @@ inline bool operator==(const matrix& lhs, const matrix& rhs)
     return true;
 }
 
-code_word row_dot(const code_word r1, const code_word r2)
+size_t row_dot(const code_word r1, const code_word r2)
 {
     return row_weight(r1 & r2) % 2;
 }
@@ -52,14 +52,15 @@ size_t row_weight(const code_word& r)
 
 void print_codeword(code_word r, const size_t n, const bool new_line)
 {
-    std::vector<code_word> bin;
-    for (size_t i = 0; i < n; ++i)
-    {
-        bin.push_back(r & BS1);
-        r >>= 1;
-    }
-    for (size_t i = 1; i <= n; ++i)
-        std::cout << bin[n - i];
+    // std::vector<code_word> bin;
+    // for (size_t i = 0; i < n; ++i)
+    // {
+    //     bin.push_back(r & BS1);
+    //     r >>= 1;
+    // }
+    // for (size_t i = 1; i <= n; ++i)
+    //     std::cout << bin[n - i];
+    std::cout << r;
 
     if (new_line)
         std::cout << std::endl;
@@ -199,7 +200,7 @@ void recursively_build(matrix rows,
         bool ok = true;
         for (uint64_t i = 0; i < rows.size(); ++i)
         {
-            if (BS1 == (row_dot(rows[i], rw) & BS1))
+            if (1 == row_dot(rows[i], rw))
             {
                 ok = false;
                 break;
@@ -256,7 +257,7 @@ matrix find(const uint64_t n, const uint64_t bits)
 
         for (uint64_t i = 0; i < m.size(); ++i)
         {
-            if (BS1 == (row_dot(m[i], c) & BS1))
+            if (1 == row_dot(m[i], c))
             {
                 ok = false;
                 break;

--- a/matrix.cpp
+++ b/matrix.cpp
@@ -45,15 +45,9 @@ std::vector<size_t> column_weights(const matrix& rows)
     return cols;
 }
 
-size_t row_weight(code_word r)
+size_t row_weight(const code_word& r)
 {
-    size_t wt = 0;
-    while (r > 0)
-    {
-        wt += (r & 1);
-        r >>= 1;
-    }
-    return wt;
+    return r.count();
 }
 
 void print_codeword(code_word r, const size_t n, const bool new_line)
@@ -61,7 +55,7 @@ void print_codeword(code_word r, const size_t n, const bool new_line)
     std::vector<code_word> bin;
     for (size_t i = 0; i < n; ++i)
     {
-        bin.push_back(r & 1);
+        bin.push_back(r & BS1);
         r >>= 1;
     }
     for (size_t i = 1; i <= n; ++i)
@@ -96,7 +90,8 @@ bool order_by_weight(const code_word r1, const code_word r2)
     if (wt1 > wt2)
         return false;
 
-    return (r1 > r2);
+    // return (r1 > r2);
+    return (r1.to_ullong() > r2.to_ullong());
 }
 
 code_word swap_bits(const code_word r, const size_t c1, const size_t c2)
@@ -122,7 +117,7 @@ code_word reverse(const code_word r, const size_t width)
     for (size_t i = 0; i < width; ++i)
     {
         p <<= 1;
-        p += (get_bit(r, i) ? 1 : 0);
+        p |= (get_bit(r, i) ? 1 : 0);
     }
     return p;
 }
@@ -137,7 +132,7 @@ void swap_columns(matrix& m, const size_t c1, const size_t c2)
 
 bool get_bit(const code_word r, const size_t n)
 {
-    return (1 == ((r >> n) & 1));
+    return r[n];
 }
 
 code_word set_bit(const code_word r, const size_t n, const bool bit)
@@ -195,15 +190,16 @@ void recursively_build(matrix rows,
     }
 
 
-    for (code_word rw = rows.back() - 1; rw > 0; --rw)
+    for (unsigned long long ri = rows.back().to_ullong() - 1; ri > 0; --ri)
     {
+        code_word rw = ri;
         if (0 == (row_weight(rw) & 1))
             continue;
 
         bool ok = true;
         for (uint64_t i = 0; i < rows.size(); ++i)
         {
-            if (0 != (row_dot(rows[i], rw) & 1))
+            if (BS1 == (row_dot(rows[i], rw) & BS1))
             {
                 ok = false;
                 break;
@@ -226,7 +222,7 @@ std::vector<matrix> all(const uint64_t n, const bool verbose)
     code_word mask = ((n+1) & 1); // 1 or 0.
     std::vector<matrix> matrices;
 
-    while (mask < max)
+    while (mask.to_ullong() < max.to_ullong())
     {
         code_word seed = max ^ mask;
         if (verbose)
@@ -236,8 +232,9 @@ std::vector<matrix> all(const uint64_t n, const bool verbose)
             std::cout << std::endl;
         }
 
+        // shift up by 2 bits then set the new bit to 1.
         mask <<= 2;
-        mask += 3;
+        mask |= ((BS1 << 1) & BS1);
 
         matrix test = {seed}; 
         recursively_build(test, n-1, max, matrices, verbose);
@@ -250,15 +247,16 @@ std::vector<matrix> all(const uint64_t n, const bool verbose)
 matrix find(const uint64_t n, const uint64_t bits)
 {
     matrix m;
-    const code_word max = (1 << bits);
+    const unsigned long long max = (1 << bits);
     while(m.size() < n)
     {
-        code_word c = rand() % max;
+        // TODO: this needs to be done properly
+        const code_word c = rand() % max;
         bool ok = true;
 
         for (uint64_t i = 0; i < m.size(); ++i)
         {
-            if (0 != (row_dot(m[i], c) & 1))
+            if (BS1 == (row_dot(m[i], c) & BS1))
             {
                 ok = false;
                 break;

--- a/matrix.cpp
+++ b/matrix.cpp
@@ -52,14 +52,6 @@ size_t row_weight(const code_word& r)
 
 void print_codeword(code_word r, const size_t n, const bool new_line)
 {
-    // std::vector<code_word> bin;
-    // for (size_t i = 0; i < n; ++i)
-    // {
-    //     bin.push_back(r & BS1);
-    //     r >>= 1;
-    // }
-    // for (size_t i = 1; i <= n; ++i)
-    //     std::cout << bin[n - i];
     std::cout << r;
 
     if (new_line)
@@ -219,11 +211,13 @@ void recursively_build(matrix rows,
 
 std::vector<matrix> all(const uint64_t n, const bool verbose)
 {
-    const code_word max = (1 << n) - 1;
+    code_word max = 1;
+    max <<= n;
+    // max -= 1;
     code_word mask = ((n+1) & 1); // 1 or 0.
     std::vector<matrix> matrices;
 
-    while (mask.to_ullong() < max.to_ullong())
+    while (mask.to_ullong() < max.to_ullong() - 1)
     {
         code_word seed = max ^ mask;
         if (verbose)
@@ -248,7 +242,8 @@ std::vector<matrix> all(const uint64_t n, const bool verbose)
 matrix find(const uint64_t n, const uint64_t bits)
 {
     matrix m;
-    const unsigned long long max = (1 << bits);
+    unsigned long long max = 1;
+    max <<= bits;
     while(m.size() < n)
     {
         // TODO: this needs to be done properly

--- a/matrix.h
+++ b/matrix.h
@@ -2,7 +2,23 @@
 
 #include "includes.h"
 
-typedef uint64_t code_word;
+// typedef uint64_t code_word;
+typedef std::bitset<64> code_word;
+static const code_word BS0 = 0;
+static const code_word BS1 = 1;
+// needed for the syndrome table;
+struct Comparer
+{
+    bool operator() (const code_word &b1, const code_word &b2) const
+    {
+        return b1.to_ullong() < b2.to_ullong();
+    }
+};
+
+
+typedef std::map<code_word, code_word, Comparer> syndrome_table;
+
+
 typedef std::vector<code_word> matrix;
 
 //
@@ -12,7 +28,7 @@ code_word row_add(const code_word r1, const code_word r2);
 
 size_t col_weight(const matrix& rows, const size_t c1);
 std::vector<size_t> column_weights(const matrix& rows);
-size_t row_weight(code_word r);
+size_t row_weight(const code_word& r);
 
 void print_codeword(code_word r, const size_t n, const bool new_line=true);
 void print_matrix(const matrix rows, size_t n=0);

--- a/matrix.h
+++ b/matrix.h
@@ -23,7 +23,7 @@ typedef std::vector<code_word> matrix;
 
 //
 inline bool operator==(const matrix& lhs, const matrix& rhs);
-code_word row_dot(const code_word r1, const code_word r2);
+size_t row_dot(const code_word r1, const code_word r2);
 code_word row_add(const code_word r1, const code_word r2);
 
 size_t col_weight(const matrix& rows, const size_t c1);

--- a/mceliese.cpp
+++ b/mceliese.cpp
@@ -24,7 +24,7 @@ std::vector<code_word> hackLinearComb(const std::vector<code_word>& M,
             {
                 plain <<= 1;
                 temp ^= get_bit(cipher, j);
-                plain += (temp ? 1 : 0);
+                plain |= (temp ? 1 : 0);
             }
 
             plain = reverse(plain, bits);
@@ -261,15 +261,14 @@ McEliesePrivate ReadPrivateKey(const std::string& file_path)
     getline(data_file, line);
     int from = 0;
     int comma = line.find(",", from);
-    int value = std::stoi(line.substr(from, comma - from));
-    G.push_back(value);
+
+    G.emplace_back(line.substr(from, comma - from));
     while (comma > 0)
     {
         from = comma + 1;
         comma = line.find(",", from);
 
-        value = std::stoi(line.substr(from, comma - from));
-        G.push_back(value);
+        G.emplace_back(line.substr(from, comma - from));
     }
 
     LinearCode lc = LinearCode(G, w);
@@ -279,11 +278,11 @@ McEliesePrivate ReadPrivateKey(const std::string& file_path)
     from    = 0;
     int bar = line.find("|", from);
     comma   = line.find(",", from);
-    int value2;
+    int value1, value2;
 
-    value = std::stoi(line.substr(from, bar - from));
+    value1 = std::stoi(line.substr(from, bar - from));
     value2 = std::stoi(line.substr(bar+1, comma - bar + 1));
-    permUnit p(value, value2);
+    permUnit p(value1, value2);
     P.push_back(p);
     while (comma > 0)
     {
@@ -291,10 +290,10 @@ McEliesePrivate ReadPrivateKey(const std::string& file_path)
         comma = line.find(",", from);
         bar = line.find("|", from);
 
-        value = std::stoi(line.substr(from, bar - from));
+        value1 = std::stoi(line.substr(from, bar - from));
         value2 = std::stoi(line.substr(bar+1, comma - bar + 1));
 
-        permUnit p(value, value2);
+        permUnit p(value1, value2);
         P.push_back(p);
     }
 
@@ -318,17 +317,14 @@ McEliesePublic ReadPublicKey(const std::string& file_path)
     getline(data_file, line);
     int from = 0;
     int comma = line.find(",", from);
-    int value = std::stoi(line.substr(from, comma - from));
-    G.push_back(value);;
+    G.emplace_back(line.substr(from, comma - from));
     while (comma > 0)
     {
         from = comma + 1;
         comma = line.find(",", from);
 
-        value = std::stoi(line.substr(from, comma - from));
-        G.push_back(value);
+        G.emplace_back(line.substr(from, comma - from));
     }
-    // size_t w = G.size();
     LinearCode lc(G, w);
  
     lc.set_generator(G);
@@ -337,7 +333,8 @@ McEliesePublic ReadPublicKey(const std::string& file_path)
     return lc;
 }
 
-std::vector<code_word> ReadCSV(const std::string& file_path)
+std::vector<code_word> ReadCSV(const std::string& file_path,
+                               const bool bin)
 {
     std::string line;
     std::ifstream data_file(file_path);
@@ -347,15 +344,31 @@ std::vector<code_word> ReadCSV(const std::string& file_path)
     getline(data_file, line);
     int from = 0;
     int comma = line.find(",", from);
-    int value = std::stoi(line.substr(from, comma - from));
-    message.push_back(value);;
+    int value;
+
+    if (!bin)
+    {
+        value = std::stoi(line.substr(from, comma - from));
+        message.push_back(value);
+    }
+    else
+    {
+       message.emplace_back(line.substr(from, comma - from)); 
+    }
     while (comma > 0)
     {
         from = comma + 1;
         comma = line.find(",", from);
 
-        value = std::stoi(line.substr(from, comma - from));
-        message.push_back(value);
+        if (!bin)
+        {
+            value = std::stoi(line.substr(from, comma - from));
+            message.push_back(value);
+        }
+        else
+        {
+           message.emplace_back(line.substr(from, comma - from)); 
+        }
     }
 
     return message;

--- a/mceliese.cpp
+++ b/mceliese.cpp
@@ -31,7 +31,6 @@ std::vector<code_word> hackLinearComb(const std::vector<code_word>& M,
             scrambled.push_back(plain);
         }
     }
-    std::cout << std::endl;
     return scrambled;
 }
 

--- a/mceliese.cpp
+++ b/mceliese.cpp
@@ -210,8 +210,7 @@ void SaveKeys(const McEliesePrivate& privKey,
     const matrix R = pubKey.get_gen_mat();
     for (size_t i = 0; i < R.size(); ++i)
     {
-       public_file << R[i]
-                    << (i + 1 == R.size() ? "\n" : ",");
+       public_file << R[i] << (i + 1 == R.size() ? "\n" : ",");
     }
     public_file.close();
 
@@ -227,8 +226,7 @@ void SaveKeys(const McEliesePrivate& privKey,
 
     for (size_t i = 0; i < M.size(); ++i)
     {
-       private_file << M[i]
-                   << (i + 1 == M.size() ? "\n" : ",");
+       private_file << M[i] << (i + 1 == M.size() ? "\n" : ",");
     }
     private_file << "|+|+|+|+|+|+|+|+|+|+|+|+|+|+|+|+|+|+|+|+"
                 << "|+|+|+|+|+|+|+|+|+|+|+|+|+|+|+|+|+|+|+|+|" << std::endl;

--- a/mceliese.h
+++ b/mceliese.h
@@ -1,6 +1,6 @@
 #include "linearcode.h"
 
-typedef std::tuple<uint64_t, uint64_t> permUnit;
+typedef std::tuple<size_t, size_t> permUnit;
 typedef std::vector<permUnit> permn;
 typedef std::tuple<matrix, LinearCode, permn> McEliesePrivate;
 typedef LinearCode McEliesePublic;
@@ -28,7 +28,8 @@ void SaveKeys(const McEliesePrivate& privKey,
 
 McEliesePrivate ReadPrivateKey(const std::string& file_path);
 McEliesePublic ReadPublicKey(const std::string& file_path);
-std::vector<code_word> ReadCSV(const std::string& file_path);
+std::vector<code_word> ReadCSV(const std::string& file_path,
+	                             const bool bin=false);
 
 std::vector<code_word> McE_encypt_message(const McEliesePublic& pubKey,
                                           const std::vector<code_word>& message);


### PR DESCRIPTION
The change over from `uint64_t` to `bitset<64>` appears to be successful.
However the code still fails when the total dimension is greater than 32 - so we are still wrongly using 32-bit somewhere!
:cat:

edit 1:
commit https://github.com/mawir157/cpp-mceliese/pull/1/commits/99f2f9c673f100a2301c9db995568b230fbc5b70 partially fixes the problem we can have up to a 62-dimensional vector space, but only up to 31 generating words and 31 extra bits.